### PR TITLE
Define `%||%` utility once

### DIFF
--- a/R/anchor_selection_mra.R
+++ b/R/anchor_selection_mra.R
@@ -310,9 +310,3 @@ select_anchors_mra <- function(U_original_list_pilot,
 
   return(sort(selected_anchors))
 }
-
-# Helper for null or default in function (already in hatsa_qc_plots.R, define locally or ensure source)
-# Consider moving to a utils.R file if used commonly
-if (!exists("%||%", mode = "function")) {
-  `%||%` <- function(a, b) if (is.null(a)) b else a
-} 

--- a/R/hatsa_projector.R
+++ b/R/hatsa_projector.R
@@ -686,8 +686,6 @@ summary.hatsa_projector <- function(object, ...,
   return(summary_info)
 }
 
-# Define %||% operator if it doesn't exist
-`%||%` <- function(x, y) if (is.null(x)) y else x
 
 #' Print method for summary.hatsa_projector objects
 #'

--- a/R/procrustes_alignment.R
+++ b/R/procrustes_alignment.R
@@ -404,6 +404,3 @@ perform_geometric_gpa_refinement <- function(A_originals_list,
               T_anchor_final = T_template, 
               R_bar_final = R_bar_final))
 }
-
-# Helper for Frechet mean options default (borrowed from purrr::`%||%`)
-`%||%` <- function(x, y) if (is.null(x)) y else x

--- a/R/utils-pipe.R
+++ b/R/utils-pipe.R
@@ -1,0 +1,12 @@
+#' Null coalescing operator
+#'
+#' Returns `y` if `x` is `NULL`, otherwise `x`.
+#'
+#' @param x Value that might be `NULL`.
+#' @param y Fallback value to use when `x` is `NULL`.
+#' @return `x` if not `NULL`, otherwise `y`.
+#' @noRd
+`%||%` <- function(x, y) {
+  if (is.null(x)) y else x
+}
+


### PR DESCRIPTION
## Summary
- add a new `utils-pipe.R` with a single `%||%` helper
- drop duplicated `%||%` functions from `procrustes_alignment.R`, `hatsa_projector.R`, and `anchor_selection_mra.R`
- ensure `procrustes_alignment.R` ends with a newline

## Testing
- `R -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ff429dd8832da27d44eb4813434e