### PR TITLE
Add orthonormal basis validation

### DIFF
--- a/R/projection_helpers.R
+++ b/R/projection_helpers.R
@@ -135,13 +135,36 @@ project_features_to_spectral_space <- function(feature_matrix, U_basis,
   UtU <- NULL # Define UtU outside so it's available for qr.solve if needed
 
   if (assume_orthonormal) {
-    is_orthonormal <- TRUE
+    if (k_dims_basis > V_p_basis) {
+      stop(sprintf(
+        "assume_orthonormal = TRUE but k_dims_basis (%d) > V_p_basis (%d).",
+        k_dims_basis, V_p_basis
+      ))
+    }
+    UtU <- crossprod(U_basis)
+    Id_k <- diag(k_dims_basis)
+    max_dev <- max(abs(UtU - Id_k))
+    if (max_dev < (tol_orthonormal * k_dims_basis)) {
+      is_orthonormal <- TRUE
+    } else {
+      warning(
+        sprintf(
+          "assume_orthonormal = TRUE but U_basis not orthonormal; max deviation %g exceeds tolerance.",
+          max_dev
+        )
+      )
+      # Proceed treating U_basis as non-orthonormal using computed UtU
+    }
   } else {
     # Check U_basis rank first
     qr_U <- qr(U_basis)
     if (qr_U$rank < k_dims_basis) {
-        warning(sprintf("U_basis appears rank deficient (rank %d / %d dimensions). Projection results may be unreliable or reflect a lower-dimensional space.",
-                        qr_U$rank, k_dims_basis))
+      warning(
+        sprintf(
+          "U_basis appears rank deficient (rank %d / %d dimensions). Projection results may be unreliable or reflect a lower-dimensional space.",
+          qr_U$rank, k_dims_basis
+        )
+      )
     }
     UtU <- crossprod(U_basis)
     Id_k <- diag(k_dims_basis)

--- a/tests/testthat/test-projection_helpers.R
+++ b/tests/testthat/test-projection_helpers.R
@@ -1,0 +1,26 @@
+library(testthat)
+
+
+test_that("assume_orthonormal check warns or errors appropriately", {
+  # Setup simple feature matrix and basis
+  V_p <- 5
+  C <- 3
+  features <- matrix(rnorm(V_p * C), nrow = V_p)
+
+  # Case 1: k_dims_basis > V_p_basis should error
+  k_big <- V_p + 1
+  U_big <- matrix(rnorm(V_p * k_big), nrow = V_p)
+  expect_error(
+    project_features_to_spectral_space(features, U_big, assume_orthonormal = TRUE)
+  )
+
+  # Case 2: basis not orthonormal triggers warning and falls back
+  k <- 3
+  U_non_ortho <- matrix(rnorm(V_p * k), nrow = V_p)
+  expect_warning(
+    res_warn <- project_features_to_spectral_space(features, U_non_ortho, assume_orthonormal = TRUE),
+    "not orthonormal"
+  )
+  res_regular <- project_features_to_spectral_space(features, U_non_ortho, assume_orthonormal = FALSE)
+  expect_equal(res_warn, res_regular)
+})


### PR DESCRIPTION
## Summary
- verify orthonormality even when `assume_orthonormal = TRUE`
- warn or error if assumption is violated
- add test for these failure modes

## Testing
- `Rscript -e "library(testthat); test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ff631080832d9c8df7e5b307c742