### PR TITLE
Add row count check for connectivity graph

### DIFF
--- a/R/spectral_graph_construction.R
+++ b/R/spectral_graph_construction.R
@@ -19,6 +19,7 @@
 #' @param k_conn_pos An integer, number of positive connections to retain per node.
 #' @param k_conn_neg An integer, number of negative connections to retain per node.
 #' @param use_dtw Logical, defaults to `FALSE`. (Placeholder).
+#' @details `X_subject` must contain at least two rows (time points).
 #' @return A sparse symmetric `Matrix::dgCMatrix` of size `V_p x V_p`
 #'   representing the z-scored connectivity graph `W_conn_i`.
 #' @importFrom Matrix Matrix sparseMatrix drop0 t forceSymmetric
@@ -30,11 +31,15 @@ compute_subject_connectivity_graph_sparse <- function(X_subject, parcel_names,
   V_p <- ncol(X_subject)
   if (V_p == 0) return(Matrix::Matrix(0, 0, 0, sparse = TRUE, dimnames = list(character(0), character(0))))
 
+  T_i <- nrow(X_subject)
+  if (T_i < 2) {
+    stop("`X_subject` must have at least two rows (time points).")
+  }
+
   if (use_dtw && interactive()) {
     message("Note: DTW is not yet implemented. Proceeding with standard correlations.")
   }
-  
-  T_i <- nrow(X_subject)
+
   col_means <- colMeans(X_subject, na.rm = TRUE)
   col_sds <- apply(X_subject, 2, stats::sd, na.rm = TRUE)
   zero_var_indices <- which(col_sds == 0)

--- a/man/compute_subject_connectivity_graph_sparse.Rd
+++ b/man/compute_subject_connectivity_graph_sparse.Rd
@@ -30,6 +30,7 @@ A sparse symmetric `Matrix::dgCMatrix` of size `V_p x V_p`
 }
 \description{
 Calculates the sparse connectivity graph for a single subject.
+`X_subject` must contain at least two rows (time points).
 Steps:
 1. Compute pairwise Pearson correlations using a memory-efficient cross-product
    approach that avoids creating a dense `V_p \times V_p` matrix.

--- a/tests/testthat/test-spectral_graph_construction.R
+++ b/tests/testthat/test-spectral_graph_construction.R
@@ -235,6 +235,26 @@ test_that("TCK-SGC-011: compute_subject_connectivity_graph_sparse scales without
   )
 })
 
+# Test TCK-SGC-012: Input must have at least two rows
+test_that("TCK-SGC-012: compute_subject_connectivity_graph_sparse requires >=2 rows", {
+  skip_if_not_installed("Matrix")
+  library(Matrix)
+
+  X_ts <- matrix(rnorm(5), nrow = 1, ncol = 5)
+  p_names <- paste0("P", 1:5)
+
+  expect_error(
+    compute_subject_connectivity_graph_sparse(
+      X_subject = X_ts,
+      parcel_names = p_names,
+      k_conn_pos = 1,
+      k_conn_neg = 1,
+      use_dtw = FALSE
+    ),
+    regexp = "at least two rows"
+  )
+})
+
 # Test TCK-SGC-004: Symmetrization Logic
 test_that("TCK-SGC-004: Symmetrization rule application", {
   skip_if_not_installed("Matrix")


### PR DESCRIPTION
## Summary
- enforce minimum row count in `compute_subject_connectivity_graph_sparse`
- document requirement in roxygen and Rd
- test that error is thrown when fewer than two rows are supplied

## Testing
- `Rscript -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461079ed78832dbeadc9fdc0241c74