### PR TITLE
Add input validation for connectivity graph

### DIFF
--- a/R/spectral_graph_construction.R
+++ b/R/spectral_graph_construction.R
@@ -28,6 +28,17 @@ compute_subject_connectivity_graph_sparse <- function(X_subject, parcel_names,
                                                       k_conn_pos, k_conn_neg,
                                                       use_dtw = FALSE) {
   V_p <- ncol(X_subject)
+
+  if (length(parcel_names) != V_p) {
+    stop(sprintf("`parcel_names` must have length %d to match number of columns in `X_subject`.", V_p))
+  }
+  if (!is.numeric(k_conn_pos) || length(k_conn_pos) != 1 || k_conn_pos < 0 || k_conn_pos != round(k_conn_pos)) {
+    stop("`k_conn_pos` must be a non-negative integer.")
+  }
+  if (!is.numeric(k_conn_neg) || length(k_conn_neg) != 1 || k_conn_neg < 0 || k_conn_neg != round(k_conn_neg)) {
+    stop("`k_conn_neg` must be a non-negative integer.")
+  }
+
   if (V_p == 0) return(Matrix::Matrix(0, 0, 0, sparse = TRUE, dimnames = list(character(0), character(0))))
 
   if (use_dtw && interactive()) {

--- a/tests/testthat/test-spectral_graph_construction.R
+++ b/tests/testthat/test-spectral_graph_construction.R
@@ -235,6 +235,48 @@ test_that("TCK-SGC-011: compute_subject_connectivity_graph_sparse scales without
   )
 })
 
+# Test TCK-SGC-012: Input validation checks
+test_that("TCK-SGC-012: compute_subject_connectivity_graph_sparse validates inputs", {
+  skip_if_not_installed("Matrix")
+  library(Matrix)
+
+  X_small <- matrix(rnorm(10 * 3), ncol = 3)
+  p_names <- paste0("P", 1:3)
+
+  # parcel_names length mismatch
+  expect_error(
+    compute_subject_connectivity_graph_sparse(
+      X_subject = X_small,
+      parcel_names = p_names[-1],
+      k_conn_pos = 1,
+      k_conn_neg = 1
+    ),
+    "parcel_names"
+  )
+
+  # negative k_conn_pos
+  expect_error(
+    compute_subject_connectivity_graph_sparse(
+      X_subject = X_small,
+      parcel_names = p_names,
+      k_conn_pos = -1,
+      k_conn_neg = 1
+    ),
+    "k_conn_pos"
+  )
+
+  # non-integer k_conn_neg
+  expect_error(
+    compute_subject_connectivity_graph_sparse(
+      X_subject = X_small,
+      parcel_names = p_names,
+      k_conn_pos = 1,
+      k_conn_neg = 1.5
+    ),
+    "k_conn_neg"
+  )
+})
+
 # Test TCK-SGC-004: Symmetrization Logic
 test_that("TCK-SGC-004: Symmetrization rule application", {
   skip_if_not_installed("Matrix")


### PR DESCRIPTION
## Summary
- validate parameters in `compute_subject_connectivity_graph_sparse`
- test new argument checks

## Testing
- `Rscript -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846107bdf28832d9c05a2e3753d1d3c