### PR TITLE
Simplify zero-variance cleanup

### DIFF
--- a/R/spectral_graph_construction.R
+++ b/R/spectral_graph_construction.R
@@ -183,15 +183,8 @@ compute_subject_connectivity_graph_sparse <- function(X_subject, parcel_names,
   
   # Ensure zero-variance parcels have zero connections
   if (length(zero_var_indices) > 0) {
-      for (zero_idx in zero_var_indices) {
-        # Create zero slices since we know these should be all zeros
-        zero_row <- Matrix::Matrix(0, nrow=1, ncol=V_p, sparse=TRUE)
-        zero_col <- Matrix::Matrix(0, nrow=V_p, ncol=1, sparse=TRUE)
-        
-        # Replace entire rows/columns for zero-variance indices
-        W_symmetric[zero_idx, ] <- zero_row
-        W_symmetric[, zero_idx] <- zero_col
-      }
+      W_symmetric[zero_var_indices, ] <- 0
+      W_symmetric[, zero_var_indices] <- 0
       W_symmetric <- Matrix::drop0(W_symmetric)
   }
 

--- a/tests/testthat/test-spectral_graph_construction.R
+++ b/tests/testthat/test-spectral_graph_construction.R
@@ -196,6 +196,7 @@ test_that("TCK-SGC-003: compute_subject_connectivity_graph_sparse handles zero v
   # Assertions on output_W (obtained from the first call)
   expect_s4_class(output_W, "dgCMatrix")
   expect_equal(dim(output_W), c(V_p, V_p))
+  expect_true(Matrix::isSymmetric(output_W))
 
   # Check that row 3 and column 3 are all zeros
   expect_equal(nnzero(output_W[3, ]), 0) # Check row 3 non-zeros


### PR DESCRIPTION
## Summary
- simplify zero-variance handling by using direct indexing
- ensure resulting matrix remains symmetric in tests

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846107faa68832d8288379855460a8b