### PR TITLE
Add symmetry check for compute_graph_laplacian_sparse

### DIFF
--- a/R/spectral_graph_construction.R
+++ b/R/spectral_graph_construction.R
@@ -204,16 +204,21 @@ compute_subject_connectivity_graph_sparse <- function(X_subject, parcel_names,
 #' Compute sparse α-lazy random-walk normalized graph Laplacian `L = I - α D⁻¹ W`
 #'
 #' @param W_sparse A sparse, symmetric adjacency matrix (`Matrix::dgCMatrix`, `V_p x V_p`).
+#'   Symmetry is verified using \code{Matrix::isSymmetric()} (tolerance \code{1e-8});
+#'   the function stops with an error if the matrix is not symmetric.
 #' @param alpha Numeric, the laziness parameter. Default is 0.93.
 #'   Will be clamped to `[epsilon, 1]` range if outside `(0,1]`.
 #' @param degree_type Character string, how to calculate node degrees if `W_sparse` has negative values.
 #'   One of `"abs"` (default, sum of absolute weights), `"positive"` (sum of positive weights only),
 #'   or `"signed"` (sum of raw weights). Documented for clarity.
 #' @return A sparse, symmetric graph Laplacian matrix (`Matrix::dgCMatrix`, `V_p x V_p`).
-#' @importFrom Matrix Diagonal rowSums t forceSymmetric
+#' @importFrom Matrix Diagonal rowSums t forceSymmetric isSymmetric
 #' @keywords internal
 compute_graph_laplacian_sparse <- function(W_sparse, alpha = 0.93, degree_type = "abs") {
   stopifnot(inherits(W_sparse, "Matrix"))
+  if (!Matrix::isSymmetric(W_sparse, tol = 1e-8)) {
+    stop("W_sparse must be symmetric. Symmetrize the adjacency matrix before calling compute_graph_laplacian_sparse().")
+  }
   V_p <- nrow(W_sparse)
   if (V_p == 0) return(Matrix::Matrix(0,0,0,sparse=TRUE))
   

--- a/man/compute_graph_laplacian_sparse.Rd
+++ b/man/compute_graph_laplacian_sparse.Rd
@@ -7,7 +7,9 @@
 compute_graph_laplacian_sparse(W_sparse, alpha = 0.93, degree_type = "abs")
 }
 \arguments{
-\item{W_sparse}{A sparse, symmetric adjacency matrix (`Matrix::dgCMatrix`, `V_p x V_p`).}
+\item{W_sparse}{A sparse, symmetric adjacency matrix (`Matrix::dgCMatrix`, `V_p x V_p`).
+Symmetry is checked with \code{Matrix::isSymmetric()} (tolerance \code{1e-8}) and the
+function errors if the matrix is not symmetric.}
 
 \item{alpha}{Numeric, the laziness parameter. Default is 0.93.
 Will be clamped to `[epsilon, 1]` range if outside `(0,1]`.}

--- a/tests/testthat/test-spectral_graph_construction.R
+++ b/tests/testthat/test-spectral_graph_construction.R
@@ -390,6 +390,20 @@ test_that("TCK-SGC-006: compute_graph_laplacian_sparse handles zero degree nodes
   expect_equal(output_L[-3, 3], c(0, 0, 0)) # Col 3, excluding diagonal
 })
 
+# Test TCK-SGC-006B: Non-symmetric input should error
+test_that("TCK-SGC-006B: compute_graph_laplacian_sparse errors for non-symmetric input", {
+  skip_if_not_installed("Matrix")
+  library(Matrix)
+
+  # Create a simple non-symmetric adjacency matrix
+  W_ns <- sparseMatrix(i = c(1, 2), j = c(2, 3), x = c(1, 1), dims = c(3, 3))
+
+  expect_error(
+    compute_graph_laplacian_sparse(W_ns),
+    regexp = "W_sparse must be symmetric"
+  )
+})
+
 # Test TCK-SGC-007: compute_spectral_sketch_sparse - Basic Correctness & Dimensions
 test_that("TCK-SGC-007: compute_spectral_sketch_sparse basic correctness & dimensions", {
   skip_if_not_installed("Matrix")


### PR DESCRIPTION
## Summary
- verify `W_sparse` symmetry with `Matrix::isSymmetric` inside `compute_graph_laplacian_sparse`
- document the new requirement in help files
- test that non-symmetric inputs produce an error

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461081442c832da7cd71c55a1b43c8