### PR TITLE
Add eigenvalue_tol parameter to spectral sketch

### DIFF
--- a/R/geo_hatsa_core_algorithm.R
+++ b/R/geo_hatsa_core_algorithm.R
@@ -136,7 +136,7 @@ run_geo_hatsa_core <- function(subject_data_list,
       L_conn_i_sparse <- compute_graph_laplacian_sparse(W_conn_i_sparse)
       
       sketch_result <- tryCatch({
-          compute_spectral_sketch_sparse(L_conn_i_sparse, spectral_rank_k)
+          compute_spectral_sketch_sparse(L_conn_i_sparse, spectral_rank_k, eigenvalue_tol = 1e-8)
       }, error = function(e) {
           message(sprintf("  Geo-HATSA Stage 1: Error computing spectral sketch for subject %d: %s", i, e$message))
           qc_metrics$sketch_computed_ok[i] <- FALSE

--- a/R/hatsa_core_algorithm.R
+++ b/R/hatsa_core_algorithm.R
@@ -155,7 +155,7 @@ run_hatsa_core <- function(subject_data_list, anchor_indices, spectral_rank_k,
                                                                   k_conn_pos, k_conn_neg, use_dtw)
       L_conn_i_sparse <- compute_graph_laplacian_sparse(W_conn_i_sparse)
 
-      sketch_result <- compute_spectral_sketch_sparse(L_conn_i_sparse, spectral_rank_k)
+      sketch_result <- compute_spectral_sketch_sparse(L_conn_i_sparse, spectral_rank_k, eigenvalue_tol = 1e-8)
       lambdas_i <- sketch_result$values
       gaps_i <- if (!is.null(lambdas_i) && length(lambdas_i) > 1) {
         denominators <- lambdas_i[-length(lambdas_i)]

--- a/R/hatsa_projector.R
+++ b/R/hatsa_projector.R
@@ -337,7 +337,7 @@ predict.hatsa_projector <- function(object, newdata_list, ...) {
 
     # 3. Compute original spectral sketch (eigenvectors)
     # compute_spectral_sketch_sparse returns a list(vectors=U, values=Lambda)
-    sketch_result_new <- compute_spectral_sketch_sparse(L_conn_new, k)
+    sketch_result_new <- compute_spectral_sketch_sparse(L_conn_new, k, eigenvalue_tol = 1e-8)
     U_orig_new <- sketch_result_new$vectors
 
     if (is.null(U_orig_new) || nrow(U_orig_new) != V_p_model || ncol(U_orig_new) != k) {

--- a/R/spectral_graph_construction.R
+++ b/R/spectral_graph_construction.R
@@ -268,16 +268,19 @@ compute_graph_laplacian_sparse <- function(W_sparse, alpha = 0.93, degree_type =
 #' @param L_conn_i_sparse A sparse graph Laplacian matrix (`Matrix::dgCMatrix`, `V_p x V_p`).
 #'   Must be symmetric.
 #' @param k An integer, the desired spectral rank. Must be `k >= 0`.
+#' @param eigenvalue_tol Numeric floor used when dynamically determining the
+#'   tolerance for filtering near-zero eigenvalues. Defaults to `1e-8`.
 #' @return A list containing two elements:
 #'   - `vectors`: A dense matrix `U_orig_i` (`V_p x k_actual`) of eigenvectors.
 #'     `k_actual` may be less than `k` if not enough informative eigenvectors are found.
 #'   - `values`: A vector of eigenvalues corresponding to the eigenvectors.
 #' @importFrom PRIMME eigs_sym
 #' @keywords internal
-compute_spectral_sketch_sparse <- function(L_conn_i_sparse, k) {
+compute_spectral_sketch_sparse <- function(L_conn_i_sparse, k,
+                                           eigenvalue_tol = 1e-8) {
   V_p <- nrow(L_conn_i_sparse)
-  # Default eigenvalue_tol, will be updated dynamically later if possible
-  eigenvalue_tol_floor <- 1e-8 
+  # Use provided eigenvalue_tol as the floor for dynamic adjustment
+  eigenvalue_tol_floor <- eigenvalue_tol
 
   if (k < 0) stop("`spectral_rank_k` (k) must be non-negative.")
   if (V_p == 0) return(list(vectors = matrix(0, 0, k), values = numeric(0)))

--- a/R/task_hatsa_helpers.R
+++ b/R/task_hatsa_helpers.R
@@ -519,7 +519,7 @@ shape_basis <- function(subject_idx, L_conn_i, L_task_i, args, W_conn_i, W_task_
     
     if (task_method == "core_hatsa") {
         sketch <- tryCatch({
-            compute_spectral_sketch_sparse(L_conn_i, spectral_rank_k)
+            compute_spectral_sketch_sparse(L_conn_i, spectral_rank_k, eigenvalue_tol = 1e-8)
         }, error = function(e) {
             warning(sprintf("Error computing spectral sketch (core) for subject %d: %s.", subject_idx, e$message)); NULL
         })
@@ -539,8 +539,8 @@ shape_basis <- function(subject_idx, L_conn_i, L_task_i, args, W_conn_i, W_task_
                  warning(sprintf("L_conn_i also NULL for subject %d. Skipping basis.", subject_idx))
                  return(result)
             }
-            sketch <- tryCatch({ 
-                compute_spectral_sketch_sparse(L_conn_i, spectral_rank_k) 
+            sketch <- tryCatch({
+                compute_spectral_sketch_sparse(L_conn_i, spectral_rank_k, eigenvalue_tol = 1e-8)
             }, error = function(e) {
                 warning(sprintf("Error computing spectral sketch (lambda_blend fallback to core L_conn) for subject %d: %s.", subject_idx, e$message)); NULL
             })
@@ -566,7 +566,7 @@ shape_basis <- function(subject_idx, L_conn_i, L_task_i, args, W_conn_i, W_task_
             if(is.null(L_hybrid_i)) return(result) # Stop if Laplacian computation failed
 
             sketch <- tryCatch({
-                compute_spectral_sketch_sparse(L_hybrid_i, spectral_rank_k)
+                compute_spectral_sketch_sparse(L_hybrid_i, spectral_rank_k, eigenvalue_tol = 1e-8)
             }, error = function(e) {
                 warning(sprintf("Error computing spectral sketch (lambda_blend) for subject %d: %s.", subject_idx, e$message)); NULL
             })
@@ -578,7 +578,7 @@ shape_basis <- function(subject_idx, L_conn_i, L_task_i, args, W_conn_i, W_task_
     } else if (task_method == "gev_patch") {
         # Core sketch
         core_sketch <- tryCatch({
-            compute_spectral_sketch_sparse(L_conn_i, spectral_rank_k)
+            compute_spectral_sketch_sparse(L_conn_i, spectral_rank_k, eigenvalue_tol = 1e-8)
         }, error = function(e) {
             warning(sprintf("Error computing spectral sketch (core for GEV) for subject %d: %s.", subject_idx, e$message)); NULL
         })

--- a/docs/T-HATSA_plan.md
+++ b/docs/T-HATSA_plan.md
@@ -64,20 +64,20 @@ The chosen name based on the discussion will be **task_hatsa (Task-Informed HATS
 3.  **Basis Shaping per Subject `i` (Based on `task_method`):**
     *   **If `task_method == "core_hatsa"`:**
         *   `L_i = compute_graph_laplacian_sparse(W_conn_i, alpha = alpha_laplacian)`.
-        *   `sketch = compute_spectral_sketch_sparse(L_i, spectral_rank_k)`.
+        *   `sketch = compute_spectral_sketch_sparse(L_i, spectral_rank_k, eigenvalue_tol = 1e-8)`.
         *   `U_original_list[[i]] = sketch$vectors`. `Lambda_original_list[[i]] = sketch$values`. `U_patch_list[[i]] = NULL`.
     *   **If `task_method == "lambda_blend"`:**
         *   `L_conn_i = compute_graph_laplacian_sparse(W_conn_i, alpha = alpha_laplacian)`.
         *   `L_task_i = compute_graph_laplacian_sparse(W_task_i, alpha = alpha_laplacian)` (using potentially residualized `W_task_i`).
         *   `L_hybrid_i = (1-lambda_blend_value)*L_conn_i + lambda_blend_value*L_task_i`.
         *   Check `eigengap_ratio_k` of `L_hybrid_i` (diagnostic, cf. threshold **~1.3-1.4**, possibly SNR dependent).
-        *   `sketch = compute_spectral_sketch_sparse(L_hybrid_i, spectral_rank_k)`.
+        *   `sketch = compute_spectral_sketch_sparse(L_hybrid_i, spectral_rank_k, eigenvalue_tol = 1e-8)`.
         *   `U_original_list[[i]] = sketch$vectors`. `Lambda_original_list[[i]] = sketch$values`. `U_patch_list[[i]] = NULL`.
     *   **If `task_method == "gev_patch"`:**
         *   `L_conn_i = compute_graph_laplacian_sparse(W_conn_i, alpha = alpha_laplacian)`.
         *   `L_task_i = compute_graph_laplacian_sparse(W_task_i, alpha = alpha_laplacian)` (using potentially residualized `W_task_i`).
         *   `gev_results = solve_gev_laplacian_primme(L_task_i, L_conn_i, k_request = k_gev_dims*2, lambda_max_thresh = gev_lambda_max, stability_r_thresh = gev_stability_r_min, epsilon_reg_L_conn = gev_epsilon_reg)`. Filter eigenvectors based on `lambda` and stability `r`. Store `U_patch_taskGEV_i` (actual `k_gev_dims` passing filters) and `Lambda_GEV_i`.
-        *   Compute core sketch: `core_sketch = compute_spectral_sketch_sparse(L_conn_i, spectral_rank_k)`.
+        *   Compute core sketch: `core_sketch = compute_spectral_sketch_sparse(L_conn_i, spectral_rank_k, eigenvalue_tol = 1e-8)`.
         *   `U_original_list[[i]] = core_sketch$vectors`. `Lambda_original_list[[i]] = core_sketch$values`.
         *   Store `U_patch_taskGEV_i`, `Lambda_GEV_i`, and GEV diagnostics separately.
 

--- a/docs/hatsa_plan.md
+++ b/docs/hatsa_plan.md
@@ -326,7 +326,7 @@ This phase addresses feedback from a detailed code review of the Nyström voxel 
     *   Review of `compute_spectral_sketch_sparse` confirms the following (updated for `L_rw_lazy`):
         *   The function calculates eigenvectors for the symmetric alpha-lazy random-walk normalized Laplacian (`L_rw_lazy`).
         *   Eigenvectors are sorted by their eigenvalues (smallest first).
-        *   An `eigenvalue_tol` (1e-8) is used to identify and **explicitly remove** eigenvectors associated with the smallest eigenvalues (corresponding to the graph's trivial/DC component(s)).
+        *   An `eigenvalue_tol` argument (default `1e-8`) is used to identify and **explicitly remove** eigenvectors associated with the smallest eigenvalues (corresponding to the graph's trivial/DC component(s)).
         *   The final `k` components selected are the first `k` from this filtered set of "non-trivial" eigenvectors.
     *   Therefore, the `spectral_rank_k` parameter in HATSA effectively requests `k` **non-DC components** derived from `L_rw_lazy`.
     *   The `U_orig_parcel` and `Lambda_orig_parcel` passed to `compute_voxel_basis_nystrom` are indeed the intended non-DC components.

--- a/docs/hatsa_test_plan.md
+++ b/docs/hatsa_test_plan.md
@@ -46,7 +46,7 @@
 
 *   **TCK-SGC-007: `compute_spectral_sketch_sparse` - Basic Correctness & Dimensions**
     *   **Synthetic Data:** Known graph Laplacian `L` (e.g., from SBM in T-1) with analytically known first few eigenvectors/values.
-    *   **Test:** Call `compute_spectral_sketch_sparse(L, k=2)`.
+    *   **Test:** Call `compute_spectral_sketch_sparse(L, k=2, eigenvalue_tol = 1e-8)`.
     *   **Assertions:**
         *   `expect_true(is.list(output))` with names "vectors" and "values".
         *   `expect_equal(dim(output$vectors), c(nrow(L), 2))`.
@@ -55,14 +55,14 @@
 
 *   **TCK-SGC-008: `compute_spectral_sketch_sparse` - Trivial Eigenvector Handling**
     *   **Synthetic Data:** Laplacian `L` from a connected graph (guaranteed zero eigenvalue).
-    *   **Test:** Call `compute_spectral_sketch_sparse(L, k=3)`. Check eigenvalues returned.
+    *   **Test:** Call `compute_spectral_sketch_sparse(L, k=3, eigenvalue_tol = 1e-8)`. Check eigenvalues returned.
     *   **Assertions:**
         *   Verify the *smallest* eigenvalue returned is `> eigenvalue_tol` (default 1e-8).
         *   Verify the eigenvector corresponding to the true zero eigenvalue was correctly discarded.
 
 *   **TCK-SGC-009: `compute_spectral_sketch_sparse` - Rank Deficiency / Insufficient Eigenvectors**
     *   **Synthetic Data:** Graph `L` designed to have fewer than `k+1` non-zero eigenvalues (e.g., multiple connected components).
-    *   **Test:** Call `compute_spectral_sketch_sparse(L, k=5)` where only, say, 3 informative eigenvectors exist.
+    *   **Test:** Call `compute_spectral_sketch_sparse(L, k=5, eigenvalue_tol = 1e-8)` where only, say, 3 informative eigenvectors exist.
     *   **Assertions:** `expect_error()` with informative message about rank deficiency.
 
 *   **TCK-SGC-010: `compute_spectral_sketch_sparse` - Edge Cases `k=0`, `k=1`**

--- a/man/compute_spectral_sketch_sparse.Rd
+++ b/man/compute_spectral_sketch_sparse.Rd
@@ -4,13 +4,16 @@
 \alias{compute_spectral_sketch_sparse}
 \title{Compute spectral sketch `U_orig_i` using `RSpectra` or `base::eigen`}
 \usage{
-compute_spectral_sketch_sparse(L_conn_i_sparse, k)
+compute_spectral_sketch_sparse(L_conn_i_sparse, k, eigenvalue_tol = 1e-8)
 }
 \arguments{
 \item{L_conn_i_sparse}{A sparse graph Laplacian matrix (`Matrix::dgCMatrix`, `V_p x V_p`).
 Must be symmetric.}
 
 \item{k}{An integer, the desired spectral rank. Must be `k >= 0`.}
+
+\item{eigenvalue_tol}{Numeric floor used when dynamically determining the
+  tolerance for filtering near-zero eigenvalues. Defaults to \code{1e-8}.}
 }
 \value{
 A list containing two elements:

--- a/tests/testthat/test-spectral_graph_construction.R
+++ b/tests/testthat/test-spectral_graph_construction.R
@@ -437,7 +437,7 @@ test_that("TCK-SGC-007: compute_spectral_sketch_sparse basic correctness & dimen
   # Function Call
   result <- NULL
   expect_no_error(
-    result <- compute_spectral_sketch_sparse(L_sparse, k = k_target)
+    result <- compute_spectral_sketch_sparse(L_sparse, k = k_target, eigenvalue_tol = 1e-8)
   )
   
   # Assertions
@@ -489,7 +489,7 @@ test_that("TCK-SGC-008: compute_spectral_sketch_sparse handles trivial eigenvect
   # Function Call
   result <- NULL
   expect_no_error(
-    result <- compute_spectral_sketch_sparse(L_path, k = k_target)
+    result <- compute_spectral_sketch_sparse(L_path, k = k_target, eigenvalue_tol = 1e-8)
   )
   
   # Assertions
@@ -540,7 +540,7 @@ test_that("TCK-SGC-009: compute_spectral_sketch_sparse handles rank deficiency",
 
   # Expect an error because we can only find 5 informative ones.
   expect_error(
-    compute_spectral_sketch_sparse(L_disconnected, k = k_target),
+    compute_spectral_sketch_sparse(L_disconnected, k = k_target, eigenvalue_tol = 1e-8),
     regexp = "Rank deficiency|too many zero eigenvalues|Found only.*informative eigenvectors.*but k=.*was requested" # Match potential error messages
   )
   
@@ -549,7 +549,7 @@ test_that("TCK-SGC-009: compute_spectral_sketch_sparse handles rank deficiency",
   # So, the function should still error because 4 < 5.
   k_target_boundary = num_non_zero_eigenvals # Request 5
   expect_error(
-    compute_spectral_sketch_sparse(L_disconnected, k = k_target_boundary),
+    compute_spectral_sketch_sparse(L_disconnected, k = k_target_boundary, eigenvalue_tol = 1e-8),
     regexp = "Rank deficiency|too many zero eigenvalues|Found only.*informative eigenvectors.*but k=.*was requested",
     info=paste("Boundary case k=", k_target_boundary, "should error if eigs_sym doesn't return enough.")
   )
@@ -571,7 +571,7 @@ test_that("TCK-SGC-010: compute_spectral_sketch_sparse edge cases k=0, k=1", {
   # --- Test k = 0 --- 
   result_k0 <- NULL
   expect_no_error(
-    result_k0 <- compute_spectral_sketch_sparse(L_path, k = 0)
+    result_k0 <- compute_spectral_sketch_sparse(L_path, k = 0, eigenvalue_tol = 1e-8)
   )
   
   # Assertions for k=0
@@ -587,7 +587,7 @@ test_that("TCK-SGC-010: compute_spectral_sketch_sparse edge cases k=0, k=1", {
   k_target_1 <- 1
   result_k1 <- NULL
   expect_no_error(
-    result_k1 <- compute_spectral_sketch_sparse(L_path, k = k_target_1)
+    result_k1 <- compute_spectral_sketch_sparse(L_path, k = k_target_1, eigenvalue_tol = 1e-8)
   )
   
   # Assertions for k=1


### PR DESCRIPTION
## Summary
- allow tolerance override in `compute_spectral_sketch_sparse`
- propagate the new argument throughout the package and docs
- update examples and tests for the new parameter

## Testing
- `devtools::test()` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68461082f0a0832d928697980e591012