### PR TITLE
Refactor graph correlation

### DIFF
--- a/R/task_graph_construction.R
+++ b/R/task_graph_construction.R
@@ -406,59 +406,48 @@ compute_graph_correlation <- function(W_graph1, W_graph2, max_edges = 2000000) {
   summary2 <- Matrix::summary(W_graph2)
 
   # Filter for upper triangle (i < j)
-  # Using base subset for potential slight speed advantage on large summaries
-  edges1 <- subset(summary1, summary1$i < summary1$j, select = c("i", "j", "x"))
-  edges2 <- subset(summary2, summary2$i < summary2$j, select = c("i", "j", "x"))
+  edges1 <- summary1[summary1$i < summary1$j, , drop = FALSE]
+  edges2 <- summary2[summary2$i < summary2$j, , drop = FALSE]
 
-  # Rename columns for merging
-  names(edges1) <- c("row", "col", "w1")
-  names(edges2) <- c("row", "col", "w2")
-
-  # Merge based on row and col to get the union of edges (full outer join)
-  # Handle empty edge cases
   if (nrow(edges1) == 0 && nrow(edges2) == 0) {
-      return(NA_real_) # No edges in either graph
-  } else if (nrow(edges1) == 0) {
-      merged_edges <- data.frame(row = edges2$row, col = edges2$col, w1 = 0, w2 = edges2$w2)
-  } else if (nrow(edges2) == 0) {
-      merged_edges <- data.frame(row = edges1$row, col = edges1$col, w1 = edges1$w1, w2 = 0)
-  } else {
-       merged_edges <- merge(edges1, edges2, by = c("row", "col"), all = TRUE)
+    return(NA_real_)
   }
 
+  # Vectorised union using matching on edge indices
+  idx1 <- paste(edges1$i, edges1$j, sep = "-")
+  idx2 <- paste(edges2$i, edges2$j, sep = "-")
+  all_idx <- union(idx1, idx2)
+  pos1 <- match(all_idx, idx1)
+  pos2 <- match(all_idx, idx2)
+  w1 <- ifelse(is.na(pos1), 0, edges1$x[pos1])
+  w2 <- ifelse(is.na(pos2), 0, edges2$x[pos2])
 
   # Sample if needed
-  num_edges <- nrow(merged_edges)
+  num_edges <- length(all_idx)
   if (num_edges > max_edges && is.finite(max_edges) && max_edges > 0) {
     if (interactive()) {
-        message(sprintf("Sampling %d edges from union of %d for correlation calculation.", max_edges, num_edges))
+      message(sprintf("Sampling %d edges from union of %d for correlation calculation.", max_edges, num_edges))
     }
     sample_indices <- sample.int(num_edges, size = max_edges, replace = FALSE)
-    merged_edges <- merged_edges[sample_indices, ]
+    w1 <- w1[sample_indices]
+    w2 <- w2[sample_indices]
+    num_edges <- max_edges
   }
 
-  # Fill missing values (NAs introduced by the full outer join) with 0
-  merged_edges$w1[is.na(merged_edges$w1)] <- 0
-  merged_edges$w2[is.na(merged_edges$w2)] <- 0
-
-  # Compute Spearman correlation
-  if (nrow(merged_edges) < 2) {
+  if (num_edges < 2) {
     warning("Too few edges (< 2) in the sampled union to compute correlation. Returning NA.")
     return(NA_real_)
   }
 
   # Check for zero variance before attempting correlation
-  sd1 <- stats::sd(merged_edges$w1)
-  sd2 <- stats::sd(merged_edges$w2)
+  sd1 <- stats::sd(w1)
+  sd2 <- stats::sd(w2)
 
-  # Handle cases where correlation is undefined
-  # stats::cor returns NA in these cases already, but adding a warning is helpful.
   if (is.na(sd1) || sd1 == 0 || is.na(sd2) || sd2 == 0) {
     warning("Zero variance in edge weights for at least one graph in the sampled union set. Correlation is undefined (NA).")
-    # Let stats::cor return NA
   }
 
-  rho <- stats::cor(merged_edges$w1, merged_edges$w2, method = "spearman", use = "complete.obs") # use="complete.obs" shouldn't be needed after NA fill
+  rho <- stats::cor(w1, w2, method = "spearman", use = "complete.obs")
 
   return(rho)
 }

--- a/docs/T-HATSA_plan.md
+++ b/docs/T-HATSA_plan.md
@@ -204,7 +204,7 @@ The chosen name based on the discussion will be **task_hatsa (Task-Informed HATS
 
 **Module: Testing (task_hatsa Specific)**
 *   `[ ]` **TCK-TSKTST-001:** Test `compute_W_task_from_activations` and `compute_W_task_from_encoding` (incl. similarity methods).
-*   `[ ]` **TCK-TSKTST-002:** Test `compute_graph_correlation` (union/zero-fill Spearman).
+*   `[X]` **TCK-TSKTST-002:** Test `compute_graph_correlation` (union/zero-fill Spearman).
 *   `[ ]` **TCK-TSKTST-004:** Test `residualize_graph_on_subspace` (low-rank formula, re-sparsify, re-z-score).
 *   `[ ]` **TCK-TSKTST-005:** Test `project_features_to_spectral_space` (orthogonal projection logic).
 *   `[ ]` **TCK-TSKTST-005.5 (NEW):** Test `residualize_matrix_on_subspace`.

--- a/tests/testthat/test-compute_graph_correlation.R
+++ b/tests/testthat/test-compute_graph_correlation.R
@@ -1,0 +1,50 @@
+library(testthat)
+library(Matrix)
+
+describe("compute_graph_correlation", {
+
+  test_that("handles empty graphs", {
+    V <- 5
+    W1 <- Matrix::Matrix(0, nrow = V, ncol = V, sparse = TRUE)
+    W2 <- Matrix::Matrix(0, nrow = V, ncol = V, sparse = TRUE)
+    expect_true(is.na(compute_graph_correlation(W1, W2)))
+  })
+
+  test_that("sampling uses set.seed reproducibly", {
+    set.seed(123)
+    V <- 20
+    mat1 <- matrix(rnorm(V * V), V, V)
+    mat1 <- (mat1 + t(mat1)) / 2
+    diag(mat1) <- 0
+    W1 <- Matrix::Matrix(mat1, sparse = TRUE)
+    W1@x <- scale(W1@x)[,1]
+
+    mat2 <- matrix(rnorm(V * V), V, V)
+    mat2 <- (mat2 + t(mat2)) / 2
+    diag(mat2) <- 0
+    W2 <- Matrix::Matrix(mat2, sparse = TRUE)
+    W2@x <- scale(W2@x)[,1]
+
+    set.seed(1)
+    rho1 <- compute_graph_correlation(W1, W2, max_edges = 10)
+    set.seed(1)
+    rho2 <- compute_graph_correlation(W1, W2, max_edges = 10)
+    expect_equal(rho1, rho2)
+    expect_true(is.numeric(rho1))
+  })
+
+  test_that("returns NA when edge variance is zero", {
+    V <- 4
+    mat1 <- matrix(0, V, V)
+    mat1[upper.tri(mat1)] <- 1
+    mat1 <- mat1 + t(mat1)
+    diag(mat1) <- 0
+    W1 <- Matrix::Matrix(mat1, sparse = TRUE)
+    W1@x <- rep(1, length(W1@x))
+    W2 <- Matrix::Matrix(0, nrow = V, ncol = V, sparse = TRUE)
+
+    expect_warning(res <- compute_graph_correlation(W1, W2), "Zero variance")
+    expect_true(is.na(res))
+  })
+
+})


### PR DESCRIPTION
## Summary
- streamline `compute_graph_correlation` by using vectorized union of edges
- mark correlation tests ticket complete
- add unit tests for empty graphs, sampling reproducibility, and zero-variance

## Testing
- `Rscript -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846128d5e34832db453d74153665b51