### PR TITLE
Enforce non-negative k_conn_task_*

### DIFF
--- a/R/task_graph_construction.R
+++ b/R/task_graph_construction.R
@@ -7,9 +7,9 @@
 #'   of conditions/features and `V_p` is the number of parcels. Each column
 #'   represents the activation profile for a parcel.
 #' @param parcel_names A character vector of length `V_p` specifying parcel names.
-#' @param k_conn_task_pos Integer, number of strongest positive connections to
+#' @param k_conn_task_pos Non-negative integer. Number of strongest positive connections to
 #'   retain per parcel during sparsification.
-#' @param k_conn_task_neg Integer, number of strongest negative connections to
+#' @param k_conn_task_neg Non-negative integer. Number of strongest negative connections to
 #'   retain per parcel during sparsification.
 #' @param similarity_method Character string or function. Specifies the method to
 #'   compute the initial `V_p x V_p` similarity matrix from `activation_matrix`.
@@ -34,6 +34,15 @@ compute_W_task_from_activations <- function(activation_matrix,
 
   V_p <- ncol(activation_matrix)
   C_n <- if (is.matrix(activation_matrix)) nrow(activation_matrix) else 0 # Number of conditions/rows
+
+  if (!is.numeric(k_conn_task_pos) || length(k_conn_task_pos) != 1 ||
+      k_conn_task_pos < 0 || k_conn_task_pos != round(k_conn_task_pos)) {
+    stop("`k_conn_task_pos` must be a non-negative integer.")
+  }
+  if (!is.numeric(k_conn_task_neg) || length(k_conn_task_neg) != 1 ||
+      k_conn_task_neg < 0 || k_conn_task_neg != round(k_conn_task_neg)) {
+    stop("`k_conn_task_neg` must be a non-negative integer.")
+  }
 
   if (V_p == 0) {
     # Ensure consistent return type (dgCMatrix) for empty graph
@@ -204,9 +213,9 @@ compute_W_task_from_activations <- function(activation_matrix,
 #'   is the number of parcels and `N_features` is the number of encoding features.
 #'   Each row represents the encoding weight profile for a parcel.
 #' @param parcel_names A character vector of length `V_p` specifying parcel names.
-#' @param k_conn_task_pos Integer, number of strongest positive connections to
+#' @param k_conn_task_pos Non-negative integer. Number of strongest positive connections to
 #'   retain per parcel during sparsification.
-#' @param k_conn_task_neg Integer, number of strongest negative connections to
+#' @param k_conn_task_neg Non-negative integer. Number of strongest negative connections to
 #'   retain per parcel during sparsification.
 #' @param similarity_method Character string or function. Specifies the method to
 #'   compute the initial `V_p x V_p` similarity matrix.
@@ -229,6 +238,15 @@ compute_W_task_from_encoding <- function(encoding_weights_matrix,
 
   V_p <- nrow(encoding_weights_matrix) # Parcels are rows
   N_features <- ncol(encoding_weights_matrix)
+
+  if (!is.numeric(k_conn_task_pos) || length(k_conn_task_pos) != 1 ||
+      k_conn_task_pos < 0 || k_conn_task_pos != round(k_conn_task_pos)) {
+    stop("`k_conn_task_pos` must be a non-negative integer.")
+  }
+  if (!is.numeric(k_conn_task_neg) || length(k_conn_task_neg) != 1 ||
+      k_conn_task_neg < 0 || k_conn_task_neg != round(k_conn_task_neg)) {
+    stop("`k_conn_task_neg` must be a non-negative integer.")
+  }
 
   if (V_p == 0) {
     # Ensure consistent return type (dgCMatrix) for empty graph

--- a/tests/testthat/test-task_graph_construction.R
+++ b/tests/testthat/test-task_graph_construction.R
@@ -155,7 +155,29 @@ describe("compute_W_task_from_activations", {
     )
     expect_s4_class(W_task_c1, "dgCMatrix")
     expect_equal(dim(W_task_c1), c(V_p,V_p))
-    expect_equal(length(W_task_c1@x), 0) 
+    expect_equal(length(W_task_c1@x), 0)
+  })
+
+  it("errors for invalid k_conn_task_pos or k_conn_task_neg", {
+    activation_matrix <- matrix(rnorm(C * V_p), nrow = C, ncol = V_p)
+    expect_error(
+      compute_W_task_from_activations(
+        activation_matrix = activation_matrix,
+        parcel_names = parcel_names,
+        k_conn_task_pos = -1,
+        k_conn_task_neg = 1
+      ),
+      "k_conn_task_pos"
+    )
+    expect_error(
+      compute_W_task_from_activations(
+        activation_matrix = activation_matrix,
+        parcel_names = parcel_names,
+        k_conn_task_pos = 1,
+        k_conn_task_neg = -1
+      ),
+      "k_conn_task_neg"
+    )
   })
 
 }) # end describe compute_W_task_from_activations
@@ -288,6 +310,29 @@ describe("compute_W_task_from_encoding", {
     expect_s4_class(W_task, "dgCMatrix")
     expect_equal(dim(W_task), c(V_p,V_p))
     expect_equal(length(W_task@x), 0) # Graph should be empty
+  })
+
+  it("errors for invalid k_conn_task_pos or k_conn_task_neg for encoding", {
+    encoding_matrix <- matrix(rnorm(V_p * N_features), nrow = V_p, ncol = N_features)
+    rownames(encoding_matrix) <- parcel_names
+    expect_error(
+      compute_W_task_from_encoding(
+        encoding_weights_matrix = encoding_matrix,
+        parcel_names = parcel_names,
+        k_conn_task_pos = -1,
+        k_conn_task_neg = 1
+      ),
+      "k_conn_task_pos"
+    )
+    expect_error(
+      compute_W_task_from_encoding(
+        encoding_weights_matrix = encoding_matrix,
+        parcel_names = parcel_names,
+        k_conn_task_pos = 1,
+        k_conn_task_neg = -1
+      ),
+      "k_conn_task_neg"
+    )
   })
 
 }) # end describe compute_W_task_from_encoding 


### PR DESCRIPTION
## Summary
- document non-negative constraints for k_conn_task_pos and k_conn_task_neg
- validate sparsification parameters inside compute_W_task_from_* functions
- add tests for invalid task graph sparsification parameters

## Testing
- `devtools::test()` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6846128b2a34832d8f4d8124a685d436