### PR TITLE
Remove message_stage stub

### DIFF
--- a/R/task_hatsa_main.R
+++ b/R/task_hatsa_main.R
@@ -169,15 +169,6 @@ run_task_hatsa <- function(
     return(result)
 }
 
-# # Helper for status messages (can be moved to utils)
-# message_stage <- function(message_text, verbose = TRUE) {
-#     if (verbose) {
-#         message(rep("-", nchar(message_text)))
-#         message(message_text)
-#         message(rep("-", nchar(message_text)))
-#     }
-# }
-
 #' Advanced Options for Task-Informed HATSA
 #'
 #' Creates a list of advanced parameters for the task_hatsa function.


### PR DESCRIPTION
## Summary
- drop commented message_stage helper
- ensure utils.R provides the only message_stage implementation

## Testing
- `R CMD build . --no-build-vignettes --no-manual` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684612a03a18832d8d9264c5b8ea4b77