### PR TITLE
Allow precomputed voxel-parcel matrix

### DIFF
--- a/man/project_voxels.hatsa_projector.Rd
+++ b/man/project_voxels.hatsa_projector.Rd
@@ -11,6 +11,7 @@
   parcel_coords,
   n_nearest_parcels = 10,
   kernel_sigma = "auto",
+  W_vox_parc = NULL,
   data_type = c("timeseries", "coefficients"),
   ...
 )
@@ -32,6 +33,11 @@ Passed to \code{\link{compute_voxel_basis_nystrom}}.}
 
 \item{kernel_sigma}{Numeric or "auto", kernel bandwidth for Nyström extension.
 Passed to \code{\link{compute_voxel_basis_nystrom}}.}
+
+\item{W_vox_parc}{Optional pre-computed voxel-to-parcel affinity matrix
+  (V_v x V_p). If supplied, this matrix is reused for all subjects and the
+  internal k-NN search is skipped. If \code{NULL}, the matrix is computed once
+  using \code{n_nearest_parcels} and \code{kernel_sigma} and then reused.}
 
 \item{data_type}{Character string, either "timeseries" (default) or
 "coefficients". If "timeseries", the projection involves scaling by `1/T_i`


### PR DESCRIPTION
## Summary
- support optional `W_vox_parc` argument for `project_voxels.hatsa_projector`
- precompute voxel-parcel affinities once when not supplied
- document new argument in Rd
- test using precomputed matrix

## Testing
- `R` *missing*, cannot run `devtools::test()`

------
https://chatgpt.com/codex/tasks/task_e_684612a98760832db69c59f59e7bb962