### PR TITLE
Add check on n_nearest_parcels

### DIFF
--- a/R/voxel_projection.R
+++ b/R/voxel_projection.R
@@ -13,7 +13,8 @@
 #'   original parcel-level eigenvalues. Values should be positive.
 #' @param n_nearest_parcels An integer, the number of nearest parcels (k_nn) to
 #'   consider for each voxel when constructing the affinity matrix *if* `W_vox_parc`
-#'   is not provided. Must be at least 1. Ignored if `W_vox_parc` is provided.
+#'   is not provided. Must be at least 1 and cannot exceed the number of parcels
+#'   (`nrow(parcel_coords)`). Ignored if `W_vox_parc` is provided.
 #' @param kernel_sigma A numeric scalar, the bandwidth (sigma) for the Gaussian kernel,
 #'   or the string \"auto\". Used only *if* `W_vox_parc` is not provided.
 #'   If \"auto\", sigma is estimated as
@@ -83,7 +84,13 @@ compute_voxel_basis_nystrom <- function(voxel_coords, parcel_coords,
 
   if (is.null(W_vox_parc)) {
     # 1. Find k_nn nearest parcel centroids for each voxel
-    if (n_nearest_parcels < 1) stop("`n_nearest_parcels` must be at least 1.")
+    if (n_nearest_parcels < 1) {
+      stop("`n_nearest_parcels` must be at least 1.")
+    }
+    if (n_nearest_parcels > V_p) {
+      stop(sprintf("`n_nearest_parcels` (%d) cannot exceed the number of parcels (%d).",
+                   n_nearest_parcels, V_p))
+    }
     nn_results <- RANN::nn2(data = parcel_coords, query = voxel_coords, k = n_nearest_parcels, treetype = "kd")
     
     # nn_results$nn.idx gives V_v x n_nearest_parcels matrix of parcel indices

--- a/man/compute_voxel_basis_nystrom.Rd
+++ b/man/compute_voxel_basis_nystrom.Rd
@@ -30,7 +30,8 @@ original parcel-level eigenvalues. Values should be positive.}
 
 \item{n_nearest_parcels}{An integer, the number of nearest parcels (k_nn) to
 consider for each voxel when constructing the affinity matrix *if* `W_vox_parc`
-is not provided. Must be at least 1. Ignored if `W_vox_parc` is provided.}
+is not provided. Must be at least 1 and not exceed the number of parcels
+(\code{nrow(parcel_coords)}). Ignored if \code{W_vox_parc} is provided.}
 
 \item{kernel_sigma}{A numeric scalar, the bandwidth (sigma) for the Gaussian kernel,
 or the string \"auto\". Used only *if* `W_vox_parc` is not provided.

--- a/tests/testthat/test-voxel_projection.R
+++ b/tests/testthat/test-voxel_projection.R
@@ -134,6 +134,11 @@ test_that("compute_voxel_basis_nystrom: basic functionality and dimensions", {
     voxel_coords, parcel_coords, parcel_comps$U_orig_parcel, parcel_comps$Lambda_orig_parcel,
     n_nearest_parcels = 0
   ))
+  # Error when n_nearest_parcels exceeds number of parcels
+  expect_error(compute_voxel_basis_nystrom(
+    voxel_coords, parcel_coords, parcel_comps$U_orig_parcel, parcel_comps$Lambda_orig_parcel,
+    n_nearest_parcels = V_p + 1
+  ))
   
   # Error for invalid kernel_sigma
   expect_error(compute_voxel_basis_nystrom(


### PR DESCRIPTION
## Summary
- enforce `n_nearest_parcels` cannot exceed the number of parcels
- document new restriction in code and Rd
- test that using too many neighbors throws an error

## Testing
- `Rscript --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684612ab9db8832db641c0a8ca94a16d