### PR TITLE
Remove Matrix::t import from voxel basis doc

### DIFF
--- a/R/voxel_projection.R
+++ b/R/voxel_projection.R
@@ -41,7 +41,7 @@
 #'   components (k), this matrix can be memory-intensive (e.g., V_v=400k, k=50
 #'   using 8-byte doubles is ~153MB).
 #'
-#' @importFrom Matrix Matrix Diagonal sparseMatrix t 
+#' @importFrom Matrix Matrix Diagonal sparseMatrix
 #' @keywords internal
 #' @examples
 #' # V_p <- 100; V_v <- 500; k <- 10; n_nearest <- 5; sigma <- 5


### PR DESCRIPTION
## Summary
- remove Matrix::t from compute_voxel_basis_nystrom documentation

## Testing
- `R -q -e "devtools::document(roclets=c('namespace'))"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684612af0b88832db90657274e36cf0d