### PR TITLE
Fix spectral_rank retrieval

### DIFF
--- a/R/task_hatsa_helpers.R
+++ b/R/task_hatsa_helpers.R
@@ -354,7 +354,6 @@ process_single_subject <- function(subject_idx, subj_data_i, task_data_i, args) 
     parcel_names <- args$parcel_names
     k_conn_pos <- args$k_conn_pos
     k_conn_neg <- args$k_conn_neg
-    spectral_rank_k <- args$spectral_rank_k # Used in shape_basis
     task_method <- args$task_method # Used in shape_basis and here
     
     # Basic validation of subject data


### PR DESCRIPTION
## Summary
- remove unused `spectral_rank_k` variable from `process_single_subject`

## Testing
- `R -q -e 'devtools::test()'` *(fails: R command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684612f5c110832d8c4ef81b19a07730