### PR TITLE
Edge case for 1D weighted Procrustes

### DIFF
--- a/R/weighted_procrustes.R
+++ b/R/weighted_procrustes.R
@@ -22,6 +22,11 @@
 #'
 #' @return A `k x k` rotation matrix `R`.
 #'
+#' @details
+#' When the spectral dimension `k` is 1, the SVD-based determinant correction is
+#' unnecessary. In this case the rotation is simply the sign of the scalar
+#' cross-product `M`, i.e. `R <- matrix(sign(M), 1, 1)`.
+#'
 #' @importFrom Matrix Diagonal
 #' @importFrom stats median
 #' @export
@@ -166,10 +171,14 @@ solve_procrustes_rotation_weighted <- function(A_source, T_target,
   }
 
   M <- crossprod(A_w, T_w) # k_dims x k_dims matrix
-  
+
   if (all(abs(M) < 1e-14)) {
       warning("Cross-product matrix M (weighted) is near zero; rotation is ill-defined. Returning identity.")
       return(diag(k_dims))
+  }
+
+  if (k_dims == 1) {
+      return(matrix(sign(M), 1, 1))
   }
   
   svd_M <- svd(M)


### PR DESCRIPTION
## Summary
- describe how spectral dimension k=1 is handled in weighted Procrustes
- return sign-based rotation when k=1 without determinant correction

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846136f71c8832d89dac8e4a5f03b99