### PR TITLE
Add diagnostic tests for weighted Procrustes solver

### DIFF
--- a/tests/testthat/test-weighted_procrustes.R
+++ b/tests/testthat/test-weighted_procrustes.R
@@ -70,3 +70,41 @@ test_that("equal weights match unweighted solution", {
   expect_equal(R_eq, R_unw, tolerance = 1e-6)
 })
 
+# Edge case: weights all zero should return identity
+test_that("zero weights return identity with warning", {
+  A <- matrix(rnorm(4*2), nrow=4)
+  T <- matrix(rnorm(4*2), nrow=4)
+  expect_warning(
+    R <- solve_procrustes_rotation_weighted(
+      A, T,
+      m_parcel_rows = 2,
+      m_task_rows = 2,
+      fixed_omega_weights = list(parcel = 0, condition = 0),
+      reliability_scores = c(0,0)
+    ), "Omega weights" )
+  expect_equal(R, diag(2))
+})
+
+# k = 1 special case uses sign of cross product
+test_that("k equals one returns sign of cross product", {
+  A <- matrix(1:3, ncol=1)
+  T <- -A
+  R <- solve_procrustes_rotation_weighted(A, T, m_parcel_rows = 3, m_task_rows = 0)
+  expect_equal(R, matrix(-1,1,1))
+})
+
+# Adaptive mode handles non-finite reliability scores
+test_that("adaptive mode tolerates non-finite reliability scores", {
+  A <- matrix(rnorm(6), nrow=3)
+  T <- matrix(rnorm(6), nrow=3)
+  expect_warning(
+    R <- solve_procrustes_rotation_weighted(
+      A, T,
+      m_parcel_rows = 1,
+      m_task_rows = 2,
+      omega_mode = "adaptive",
+      reliability_scores = c(0.2, Inf),
+      fixed_omega_weights = list(parcel=1, condition=1)
+    ), "Non-finite reliability_scores" )
+  expect_equal(dim(R), c(2,2))
+})


### PR DESCRIPTION
## Summary
- extend *test-weighted_procrustes.R* with additional unit tests
  - zero-weight early return
  - k=1 sign handling
  - non‑finite reliability scores in adaptive mode

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: command not found)*
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846385a755c832db95c4002bbe15f50