### PR TITLE
Fix predict failure when PRIMME not installed

### DIFF
--- a/R/spectral_graph_construction.R
+++ b/R/spectral_graph_construction.R
@@ -348,8 +348,13 @@ compute_spectral_sketch_sparse <- function(L_conn_i_sparse, k,
   if (V_p > 1 && num_eigs_to_request >= V_p) { 
       num_eigs_to_request = V_p -1 
   }
-  if (num_eigs_to_request <=0 && V_p > 0) { 
-      use_dense_eigen <- TRUE 
+  if (num_eigs_to_request <=0 && V_p > 0) {
+      use_dense_eigen <- TRUE
+  }
+
+  if (!use_dense_eigen && !requireNamespace("PRIMME", quietly = TRUE)) {
+      use_dense_eigen <- TRUE
+      if (interactive()) message("PRIMME package not installed; falling back to base::eigen.")
   }
 
   if (use_dense_eigen) {


### PR DESCRIPTION
## Summary
- fallback to base eigen decomposition in `compute_spectral_sketch_sparse` when the PRIMME package is unavailable

## Testing
- `Rscript -e 'cat("Rscript available")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846dddb9c78832db2f307e57350c7f3