### PR TITLE
Handle NULL `use_dtw` in predictor

### DIFF
--- a/R/hatsa_projector.R
+++ b/R/hatsa_projector.R
@@ -304,7 +304,7 @@ predict.hatsa_projector <- function(object, newdata_list, ...) {
   T_anchor_final <- object$T_anchor_final
   k_conn_pos <- object$parameters$k_conn_pos
   k_conn_neg <- object$parameters$k_conn_neg
-  use_dtw_model <- object$parameters$use_dtw
+  use_dtw_model <- isTRUE(object$parameters$use_dtw)
 
   aligned_sketches_new_list <- vector("list", length(newdata_list))
   for (i in seq_along(newdata_list)) {

--- a/R/spectral_graph_construction.R
+++ b/R/spectral_graph_construction.R
@@ -64,6 +64,7 @@ chunked_sparse_cor <- function(X_centered, col_sds, block_size = 50L) {
 compute_subject_connectivity_graph_sparse <- function(X_subject, parcel_names,
                                                       k_conn_pos, k_conn_neg,
                                                       use_dtw = FALSE) {
+  use_dtw <- isTRUE(use_dtw)
   V_p <- ncol(X_subject)
 
   if (length(parcel_names) != V_p) {


### PR DESCRIPTION
## Summary
- coerce `use_dtw` parameter in `compute_subject_connectivity_graph_sparse`
- default to `FALSE` when retrieving `use_dtw` during prediction

## Testing
- `Rscript -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ddef30a8832d8598372d120a0930